### PR TITLE
throw an error when response != ok

### DIFF
--- a/src/createFetchWrapper.ts
+++ b/src/createFetchWrapper.ts
@@ -23,10 +23,15 @@ export default function createFetchWrapper(apiKey: string, type: AllowedTypes) {
   const baseUrl = baseUrls[type];
 
   return <T extends Params>(path: string, params?: T) =>
-    fetch(
-      `${baseUrl}${path}?${stringifyParams(params || {})}`,
-      options
-    ).then((response) => response.json());
+    fetch(`${baseUrl}${path}?${stringifyParams(params || {})}`, options).then(
+      (response) => {
+        if (!response.ok) {
+          throw new Error(response.statusText);
+        }
+
+        return response.json();
+      }
+    );
 }
 
 function stringifyParams<T extends Params>(params: T) {


### PR DESCRIPTION
So I used an invalid API key and the API response is correct with `403`, however, using the `client` here, it doesn't `catch` this as error. According to MDN, [`fetch`'s returned promise **won't reject on HTTP error status**](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch). This patch checks and throws an `Error` when response is NOT ok!


Example code below:

```javascript
client.photos.curated()
	.then((result) => console.log(result)) // always goes here
	.catch(err => console.error(err)) // never goes here
```
