### PR TITLE
Added missing types to the Photo interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface Photo {
   height: number;
   url: string;
   alt: string | null;
-  avg_color: string;
+  avg_color: string | null;
   photographer: string;
   photographer_url: string;
   photographer_id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,8 @@ export interface Photo {
   width: number;
   height: number;
   url: string;
+  alt: string;
+  avg_color: string;
   photographer: string;
   photographer_url: string;
   photographer_id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface Photo {
   width: number;
   height: number;
   url: string;
-  alt: string;
+  alt: string | null;
   avg_color: string;
   photographer: string;
   photographer_url: string;


### PR DESCRIPTION
### Why?
This small PR addresses 2 of the missing types in the Photo interface -- alt and avg_color. I was creating an image carousel and was hoping to use the alt tag for accessibility, and the avg_color as a skeleton screen color when loading my images. These types are listed in the [JavaScript Photo Resource Response](https://www.pexels.com/api/documentation/?language=javascript#photos-overview) documentation but when I went to map over my array to create the carousel, I had TS2339 error due to the properties not existing on the Photo type.

<img width="845" alt="Screen Shot 2022-01-23 at 7 24 00 PM" src="https://user-images.githubusercontent.com/32374789/150717171-ec12cfe0-9556-4839-b1bb-5df02cd2d176.png">

Let me know if there's any questions and thanks so much for the awesome Pexel JavaScript wrapper :)
