### PR TITLE
Update createClient.ts

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -1,4 +1,4 @@
-require("isomorphic-fetch");
+const iso = require("isomorphic-fetch");
 
 import generateCollectionEndpoints from "./generateCollectionEndpoints";
 import generatePhotoEndpoints from "./generatePhotoEndpoints";


### PR DESCRIPTION
The encountered error, 
`Uncaught ReferenceError: require is not defined, on index-02e8d2ce.js: 40: 59177`
 arises due to an _inconsistency between the ES modules syntax used in the code and the expected behavior of the production environment_. Although the code employs the correct ES modules import statement
` import { createClient } from "pexels";`,
 the error suggests that the production build process isn't correctly handling this syntax. 