### PR TITLE
fix: add total_count to curated photos endpoint types

### DIFF
--- a/src/generatePhotoEndpoints.ts
+++ b/src/generatePhotoEndpoints.ts
@@ -3,13 +3,12 @@ import {
   Photo,
   PaginationParams,
   ErrorResponse,
-  Photos,
   PhotosWithTotalResults,
 } from "./types";
 import { isPhotos } from "./typeCheckers";
 
 type SearchReturn = PhotosWithTotalResults | ErrorResponse;
-type CuratedReturn = Photos | ErrorResponse;
+type CuratedReturn = PhotosWithTotalResults | ErrorResponse;
 type ShowReturn = Photo | ErrorResponse;
 type RandomReturn = Photo | ErrorResponse;
 


### PR DESCRIPTION
### Problem 
Right now, when one calls the curated photos endpoint via this JS SDK, the typing suggests that there is no `total_count` in the response. I've checked the current API response and found that this endpoint in fact returns such a field as well.

### Solution
This PR adds the `total_count` field to the types of the curated photos endpoint.